### PR TITLE
feat: Implement "Remember Me" and cache interests/weather

### DIFF
--- a/app/src/main/java/com/g22/orbitsoundkotlin/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/data/UserPreferencesRepository.kt
@@ -11,6 +11,8 @@ import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.first
+import org.json.JSONArray
 
 private val Context.dataStore by preferencesDataStore(name = "user_preferences")
 
@@ -27,6 +29,7 @@ class UserPreferencesRepository(
 ) {
     private val rememberKey = booleanPreferencesKey("remember_me")
     private val emailKey = stringPreferencesKey("remember_email")
+    private val lastInterestsKey = stringPreferencesKey("last_selected_interests")
 
     val rememberSettings: Flow<RememberSettings> = dataStore.data
         .catch { emit(emptyPreferences()) }
@@ -46,6 +49,47 @@ class UserPreferencesRepository(
                 prefs.remove(rememberKey)
                 prefs.remove(emailKey)
             }
+        }
+    }
+
+    suspend fun getLastSelectedInterests(): List<String> {
+        return dataStore.data
+            .catch { emit(emptyPreferences()) }
+            .map { prefs ->
+                prefs[lastInterestsKey]?.let(::decodeInterests) ?: emptyList()
+            }
+            .first()
+    }
+
+    suspend fun saveLastSelectedInterests(interests: List<String>) {
+        dataStore.edit { prefs ->
+            if (interests.isEmpty()) {
+                prefs.remove(lastInterestsKey)
+            } else {
+                prefs[lastInterestsKey] = encodeInterests(interests)
+            }
+        }
+    }
+
+    private fun encodeInterests(interests: List<String>): String {
+        val jsonArray = JSONArray()
+        interests.forEach { jsonArray.put(it) }
+        return jsonArray.toString()
+    }
+
+    private fun decodeInterests(raw: String): List<String> {
+        return try {
+            val jsonArray = JSONArray(raw)
+            buildList {
+                for (index in 0 until jsonArray.length()) {
+                    val value = jsonArray.optString(index)
+                    if (!value.isNullOrEmpty()) {
+                        add(value)
+                    }
+                }
+            }
+        } catch (_: Exception) {
+            emptyList()
         }
     }
 }

--- a/app/src/main/java/com/g22/orbitsoundkotlin/data/local/RememberMeStorage.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/data/local/RememberMeStorage.kt
@@ -1,0 +1,42 @@
+package com.g22.orbitsoundkotlin.data.local
+
+import android.content.Context
+import android.content.SharedPreferences
+
+data class RememberMeEntry(
+    val remember: Boolean,
+    val email: String
+)
+
+class RememberMeStorage(context: Context) {
+
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun load(): RememberMeEntry {
+        val remember = prefs.getBoolean(KEY_REMEMBER, false)
+        val email = prefs.getString(KEY_EMAIL, "") ?: ""
+        return RememberMeEntry(remember = remember, email = email)
+    }
+
+    fun save(remember: Boolean, email: String) {
+        prefs.edit()
+            .putBoolean(KEY_REMEMBER, remember)
+            .putString(KEY_EMAIL, email)
+            .apply()
+    }
+
+    fun clear() {
+        prefs.edit()
+            .remove(KEY_REMEMBER)
+            .remove(KEY_EMAIL)
+            .apply()
+    }
+
+    private companion object {
+        const val PREFS_NAME = "auth_remember_me"
+        const val KEY_REMEMBER = "remember"
+        const val KEY_EMAIL = "email"
+    }
+}
+

--- a/app/src/main/java/com/g22/orbitsoundkotlin/ui/screens/auth/AuthScreenCallbacks.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/ui/screens/auth/AuthScreenCallbacks.kt
@@ -8,9 +8,7 @@ data class AuthScreenCallbacks(
     val onForgotPassword: (String) -> Unit = {},
     val onGoogleSignIn: () -> Unit = {},
     val onAppleSignIn: () -> Unit = {},
-    val onSpotifySignIn: () -> Unit = {},
-    val rememberMeValue: Boolean = false,
-    val onRememberMeChange: (Boolean) -> Unit = {}
+    val onSpotifySignIn: () -> Unit = {}
 )
 
 val LocalAuthScreenCallbacks = staticCompositionLocalOf { AuthScreenCallbacks() }

--- a/app/src/main/java/com/g22/orbitsoundkotlin/ui/screens/auth/LoginScreen.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/ui/screens/auth/LoginScreen.kt
@@ -66,11 +66,6 @@ fun LoginScreen(
     val callbacks = LocalAuthScreenCallbacks.current
 
     var showPassword by rememberSaveable { mutableStateOf(false) }
-    var rememberMeChecked by rememberSaveable { mutableStateOf(callbacks.rememberMeValue) }
-
-    LaunchedEffect(callbacks.rememberMeValue) {
-        rememberMeChecked = callbacks.rememberMeValue
-    }
 
     LaunchedEffect(uiState.authSuccess) {
         if (uiState.authSuccess) {
@@ -188,12 +183,9 @@ fun LoginScreen(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Center
             ) {
-                Checkbox(
-                    checked = rememberMeChecked,
-                    onCheckedChange = { checked ->
-                        rememberMeChecked = checked
-                        callbacks.onRememberMeChange(checked)
-                    },
+            Checkbox(
+                checked = uiState.rememberMe,
+                onCheckedChange = viewModel::onRememberMeChange,
                     enabled = !uiState.isLoading,
                     colors = CheckboxDefaults.colors(
                         checkedColor = focusColor,

--- a/app/src/main/java/com/g22/orbitsoundkotlin/ui/viewmodels/AuthViewModelFactory.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/ui/viewmodels/AuthViewModelFactory.kt
@@ -20,3 +20,8 @@ class AuthViewModelFactory(
     }
 }
 
+
+
+
+
+

--- a/app/src/main/java/com/g22/orbitsoundkotlin/ui/viewmodels/HomeViewModelFactory.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/ui/viewmodels/HomeViewModelFactory.kt
@@ -20,3 +20,8 @@ class HomeViewModelFactory(
     }
 }
 
+
+
+
+
+

--- a/app/src/main/java/com/g22/orbitsoundkotlin/ui/viewmodels/InterestsViewModelFactory.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/ui/viewmodels/InterestsViewModelFactory.kt
@@ -1,0 +1,24 @@
+package com.g22.orbitsoundkotlin.ui.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.g22.orbitsoundkotlin.data.UserPreferencesRepository
+import com.g22.orbitsoundkotlin.data.repositories.InterestsRepository
+
+class InterestsViewModelFactory(
+    private val interestsRepository: InterestsRepository,
+    private val preferencesRepository: UserPreferencesRepository?
+) : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(InterestsViewModel::class.java)) {
+            return InterestsViewModel(
+                interestsRepository = interestsRepository,
+                preferencesRepository = preferencesRepository
+            ) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}
+


### PR DESCRIPTION
This commit introduces several features to improve user experience and offline capabilities:

-   **"Remember Me" Functionality:** Implemented `RememberMeStorage` using `SharedPreferences` to persist the user's email and "remember me" preference. The `AuthViewModel` now loads this data on startup and saves it upon successful login.
-   **Interests Caching:** The `InterestsViewModel` now caches the last selected interests using `UserPreferencesRepository`. This ensures that a user's selections are immediately visible when returning to the screen, even before the network request completes.
-   **Weather Data Caching:** `HomeViewModel` now caches weather data to a local file. If fetching fresh weather data fails due to a network error, the app will load and display the last known weather information from the cache.
-   **ViewModel Factories:** Added `InterestsViewModelFactory` to inject dependencies (`InterestsRepository` and `UserPreferencesRepository`) into `InterestsViewModel`, facilitating better testing and architecture.