### PR TITLE
feat: Implement Captain's Log for session activity

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/app/src/main/java/com/g22/orbitsoundkotlin/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/data/local/AppDatabase.kt
@@ -13,6 +13,7 @@ import com.g22.orbitsoundkotlin.data.local.entities.*
  * Implementa el patrón Outbox y SWR para todas las operaciones.
  * 
  * Version 2: Added Library cache entities (LibrarySectionCacheEntity, SearchHistoryEntity)
+ * Version 3: Added SessionActivityLogEntity for session activity journal feature
  */
 @Database(
     entities = [
@@ -24,12 +25,17 @@ import com.g22.orbitsoundkotlin.data.local.entities.*
         OutboxEntity::class,
         // Library cache entities (v2)
         LibrarySectionCacheEntity::class,
-        SearchHistoryEntity::class
+        SearchHistoryEntity::class,
+        // Session activity logs (v3)
+        SessionActivityLogEntity::class
     ],
-    version = 2,
+    version = 3,
     exportSchema = false
 )
-@TypeConverters(StringListConverter::class, JsonConverter::class)
+@TypeConverters(
+    StringListConverter::class, 
+    JsonConverter::class
+)
 abstract class AppDatabase : RoomDatabase() {
 
     abstract fun userDao(): UserDao
@@ -39,6 +45,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun weatherCacheDao(): WeatherCacheDao
     abstract fun outboxDao(): OutboxDao
     abstract fun libraryCacheDao(): LibraryCacheDao
+    abstract fun sessionActivityLogDao(): SessionActivityLogDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/g22/orbitsoundkotlin/data/local/dao/SessionActivityLogDao.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/data/local/dao/SessionActivityLogDao.kt
@@ -1,0 +1,121 @@
+package com.g22.orbitsoundkotlin.data.local.dao
+
+import androidx.room.*
+import com.g22.orbitsoundkotlin.data.local.entities.SessionActivityLogEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * DAO para operaciones con logs de actividad de sesiones.
+ * Proporciona queries eficientes usando índices en userId y sessionStartTimestamp.
+ */
+@Dao
+interface SessionActivityLogDao {
+    
+    /**
+     * Obtiene todos los logs de sesiones para un usuario, ordenados por fecha descendente.
+     * Usa índice en userId para consulta eficiente.
+     */
+    @Query("""
+        SELECT * FROM session_activity_logs 
+        WHERE userId = :userId 
+        ORDER BY sessionStartTimestamp DESC
+    """)
+    fun getAllLogsForUser(userId: String): Flow<List<SessionActivityLogEntity>>
+    
+    /**
+     * Obtiene logs de sesiones para un usuario en un rango de tiempo.
+     * Usa índice compuesto (userId, sessionStartTimestamp) para consulta eficiente.
+     */
+    @Query("""
+        SELECT * FROM session_activity_logs 
+        WHERE userId = :userId 
+        AND sessionStartTimestamp >= :startTimestamp 
+        AND sessionStartTimestamp <= :endTimestamp
+        ORDER BY sessionStartTimestamp DESC
+    """)
+    suspend fun getLogsInTimeRange(
+        userId: String,
+        startTimestamp: Long,
+        endTimestamp: Long
+    ): List<SessionActivityLogEntity>
+    
+    /**
+     * Obtiene logs de sesiones válidos (no expirados) para un usuario.
+     * Útil para SWR pattern: servir cache válido inmediatamente.
+     */
+    @Query("""
+        SELECT * FROM session_activity_logs 
+        WHERE userId = :userId 
+        AND expiresAt > :currentTime
+        ORDER BY sessionStartTimestamp DESC
+        LIMIT :limit
+    """)
+    suspend fun getValidCache(
+        userId: String,
+        currentTime: Long = System.currentTimeMillis(),
+        limit: Int = 100
+    ): List<SessionActivityLogEntity>?
+    
+    /**
+     * Obtiene el log más reciente para un usuario.
+     */
+    @Query("""
+        SELECT * FROM session_activity_logs 
+        WHERE userId = :userId 
+        ORDER BY sessionStartTimestamp DESC 
+        LIMIT 1
+    """)
+    suspend fun getMostRecentLog(userId: String): SessionActivityLogEntity?
+    
+    /**
+     * Inserta un nuevo log de sesión.
+     * Si ya existe un log con el mismo userId y sessionStartTimestamp, lo reemplaza.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertLog(log: SessionActivityLogEntity): Long
+    
+    /**
+     * Inserta múltiples logs en batch (más eficiente que insertar uno por uno).
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertLogs(logs: List<SessionActivityLogEntity>)
+    
+    /**
+     * Elimina logs expirados para liberar espacio.
+     * Debe llamarse periódicamente (ej. al iniciar la app o en un Worker).
+     */
+    @Query("""
+        DELETE FROM session_activity_logs 
+        WHERE expiresAt < :currentTime
+    """)
+    suspend fun deleteExpiredLogs(currentTime: Long = System.currentTimeMillis())
+    
+    /**
+     * Elimina todos los logs de un usuario.
+     * Útil para limpieza de datos o logout.
+     */
+    @Query("DELETE FROM session_activity_logs WHERE userId = :userId")
+    suspend fun deleteAllLogsForUser(userId: String)
+    
+    /**
+     * Cuenta el total de logs para un usuario.
+     */
+    @Query("SELECT COUNT(*) FROM session_activity_logs WHERE userId = :userId")
+    suspend fun countLogsForUser(userId: String): Int
+    
+    /**
+     * Obtiene logs de sesiones para un período específico (último día/semana/mes).
+     */
+    @Query("""
+        SELECT * FROM session_activity_logs 
+        WHERE userId = :userId 
+        AND sessionStartTimestamp >= :periodStartTimestamp
+        ORDER BY sessionStartTimestamp DESC
+    """)
+    suspend fun getLogsForPeriod(
+        userId: String,
+        periodStartTimestamp: Long
+    ): List<SessionActivityLogEntity>
+}
+
+

--- a/app/src/main/java/com/g22/orbitsoundkotlin/data/local/dao/TelemetryDao.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/data/local/dao/TelemetryDao.kt
@@ -34,5 +34,15 @@ interface TelemetryDao {
 
     @Query("DELETE FROM login_telemetry")
     suspend fun clearAllTelemetry()
+    
+    /**
+     * Obtiene todos los logins (sincronizados y no sincronizados) en un rango de tiempo.
+     * Útil para procesar historial completo de sesiones.
+     */
+    @Query("SELECT * FROM login_telemetry WHERE timestamp >= :startTime AND timestamp <= :endTime")
+    suspend fun getTelemetryInTimeRange(
+        startTime: Long,
+        endTime: Long
+    ): List<LoginTelemetryEntity>
 }
 

--- a/app/src/main/java/com/g22/orbitsoundkotlin/data/local/entities/SessionActivityLogEntity.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/data/local/entities/SessionActivityLogEntity.kt
@@ -1,0 +1,64 @@
+package com.g22.orbitsoundkotlin.data.local.entities
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Log de actividad de sesión procesado y agregado.
+ * Almacena métricas calculadas de una sesión de usuario para evitar recálculo.
+ * 
+ * Una sesión se define como un período de actividad del usuario que comienza
+ * con un login exitoso y termina después de 30 minutos de inactividad.
+ * 
+ * Cache con TTL de 24 horas para balancear frescura vs rendimiento.
+ */
+@Entity(
+    tableName = "session_activity_logs",
+    indices = [
+        Index(value = ["userId"]),
+        Index(value = ["sessionStartTimestamp"]),
+        Index(value = ["userId", "sessionStartTimestamp"])
+    ]
+)
+data class SessionActivityLogEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val userId: String,
+    val sessionStartTimestamp: Long, // Timestamp del login que inició la sesión
+    val sessionEndTimestamp: Long,   // Timestamp del último evento + 30 min de inactividad
+    val durationMinutes: Int,        // Duración calculada en minutos
+    val loginType: String,           // Tipo de login (EMAIL_PASSWORD, GOOGLE, SPOTIFY, etc.)
+    val totalActions: Int,           // Total de acciones realizadas en la sesión
+    val actionTypesJson: String,     // JSON: Map<String, Int> (tipo de acción -> conteo)
+    val totalSearches: Int,           // Total de búsquedas realizadas
+    val searchQueriesJson: String,   // JSON: List<String> (últimas 10 búsquedas)
+    val processedAt: Long = System.currentTimeMillis(), // Timestamp de procesamiento
+    val cachedAt: Long = System.currentTimeMillis(),     // Timestamp de cache
+    val expiresAt: Long                // TTL: 24 horas por defecto
+) {
+    companion object {
+        private const val CACHE_TTL_MS = 24 * 60 * 60 * 1000L // 24 horas
+
+        /**
+         * Calcula el timestamp de expiración del cache.
+         */
+        fun calculateExpiresAt(): Long {
+            return System.currentTimeMillis() + CACHE_TTL_MS
+        }
+
+        /**
+         * Constante para ventana de sesión: 30 minutos de inactividad cierra una sesión.
+         */
+        const val SESSION_INACTIVITY_WINDOW_MS = 30 * 60 * 1000L // 30 minutos
+    }
+
+    /**
+     * Verifica si el cache está expirado.
+     */
+    fun isExpired(): Boolean {
+        return System.currentTimeMillis() > expiresAt
+    }
+}
+
+

--- a/app/src/main/java/com/g22/orbitsoundkotlin/data/repositories/SessionActivityRepository.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/data/repositories/SessionActivityRepository.kt
@@ -1,0 +1,293 @@
+package com.g22.orbitsoundkotlin.data.repositories
+
+import android.util.Log
+import com.g22.orbitsoundkotlin.data.local.AppDatabase
+import com.g22.orbitsoundkotlin.data.local.entities.*
+import com.google.gson.Gson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
+
+/**
+ * Repository para procesar y almacenar logs de actividad de sesiones.
+ * Implementa SWR pattern (Stale-While-Revalidate) para eventual connectivity.
+ * 
+ * Procesa datos desde múltiples fuentes locales:
+ * - LoginTelemetryEntity: Logins del usuario
+ * - OutboxEntity: Acciones realizadas
+ * - SearchHistoryEntity: Búsquedas realizadas
+ * 
+ * Agrupa eventos por sesión (ventana de 30 minutos de inactividad)
+ * y calcula métricas agregadas.
+ */
+class SessionActivityRepository(
+    private val db: AppDatabase
+) {
+    private val sessionLogDao = db.sessionActivityLogDao()
+    private val telemetryDao = db.telemetryDao()
+    private val outboxDao = db.outboxDao()
+    private val libraryCacheDao = db.libraryCacheDao()
+    
+    private val gson = Gson()
+    private val TAG = "SessionActivityRepo"
+    
+    /**
+     * Obtiene logs de sesiones con SWR pattern.
+     * 
+     * 1. Intenta obtener cache válido (no expirado) → retorna inmediatamente
+     * 2. Si no hay cache válido, procesa datos desde fuentes locales
+     * 3. Guarda resultado en cache para próximas consultas
+     * 4. Funciona 100% offline usando datos locales
+     * 
+     * @param userId ID del usuario (para filtrar SearchHistoryEntity y OutboxEntity)
+     * @param userEmail Email del usuario (para filtrar LoginTelemetryEntity)
+     * @param periodStartTimestamp Timestamp de inicio del período (ej. hace 2 semanas)
+     * @return Lista de logs de sesiones procesados
+     */
+    suspend fun getSessionLogs(
+        userId: String,
+        userEmail: String? = null,
+        periodStartTimestamp: Long
+    ): List<SessionActivityLogEntity> = withContext(Dispatchers.Default) {
+        
+        // SWR Step 1: Intentar obtener cache válido
+        val cachedLogs = sessionLogDao.getValidCache(userId, limit = 100)
+        if (cachedLogs != null && cachedLogs.isNotEmpty()) {
+            // Filtrar por período si es necesario
+            val filteredLogs = cachedLogs.filter { 
+                it.sessionStartTimestamp >= periodStartTimestamp 
+            }
+            if (filteredLogs.isNotEmpty()) {
+                Log.d(TAG, "✅ Cache HIT: Serving ${filteredLogs.size} cached session logs")
+                return@withContext filteredLogs
+            }
+        }
+        
+        // SWR Step 2: No hay cache válido, procesar desde datos fuente
+        Log.d(TAG, "❌ Cache MISS: Processing session logs from local data sources")
+        val processedLogs = processSessionLogsFromSources(userId, userEmail, periodStartTimestamp)
+        
+        // SWR Step 3: Guardar en cache para próximas consultas
+        if (processedLogs.isNotEmpty()) {
+            sessionLogDao.insertLogs(processedLogs)
+            Log.d(TAG, "💾 Cache UPDATED: Saved ${processedLogs.size} session logs")
+        }
+        
+        processedLogs
+    }
+    
+    /**
+     * Procesa logs de sesiones desde fuentes de datos locales.
+     * Usa procesamiento paralelo para consultar múltiples fuentes simultáneamente.
+     * 
+     * @param userId ID del usuario
+     * @param userEmail Email del usuario (para filtrar LoginTelemetryEntity)
+     * @param periodStartTimestamp Timestamp de inicio del período
+     * @return Lista de logs de sesiones procesados
+     */
+    private suspend fun processSessionLogsFromSources(
+        userId: String,
+        userEmail: String?,
+        periodStartTimestamp: Long
+    ): List<SessionActivityLogEntity> = withContext(Dispatchers.Default) {
+        
+        // Procesamiento paralelo de múltiples fuentes de datos
+        val loginDataDeferred = async {
+            // Obtener todos los logins exitosos del usuario en el período
+            getAllLoginTelemetry(userEmail, periodStartTimestamp)
+        }
+        
+        val outboxDataDeferred = async {
+            // Obtener todas las operaciones del usuario en el período
+            getAllOutboxOperations(userId, periodStartTimestamp)
+        }
+        
+        val searchDataDeferred = async {
+            // Obtener todas las búsquedas del usuario en el período
+            getAllSearchHistory(userId, periodStartTimestamp)
+        }
+        
+        // Esperar a que todas las consultas terminen (await individual para mantener tipos)
+        val loginTelemetry = loginDataDeferred.await()
+        val outboxOperations = outboxDataDeferred.await()
+        val searchHistory = searchDataDeferred.await()
+        
+        Log.d(TAG, "📊 Data sources loaded: ${loginTelemetry.size} logins, " +
+                "${outboxOperations.size} operations, ${searchHistory.size} searches")
+        
+        // Agrupar eventos por sesión y calcular métricas
+        groupEventsBySession(
+            userId = userId,
+            loginTelemetry = loginTelemetry,
+            outboxOperations = outboxOperations,
+            searchHistory = searchHistory
+        )
+    }
+    
+    /**
+     * Obtiene todos los logins exitosos del usuario en el período.
+     * Filtra por email si se proporciona, sino obtiene todos los logins exitosos.
+     * 
+     * IMPORTANTE: Obtiene TODOS los logins (sincronizados y no sincronizados)
+     * porque necesitamos procesar el historial completo de sesiones.
+     */
+    private suspend fun getAllLoginTelemetry(
+        userEmail: String?,
+        periodStartTimestamp: Long
+    ): List<LoginTelemetryEntity> = withContext(Dispatchers.IO) {
+        // Obtener TODOS los logins en el rango de tiempo (sincronizados y no sincronizados)
+        val endTime = System.currentTimeMillis()
+        val allTelemetry = telemetryDao.getTelemetryInTimeRange(periodStartTimestamp, endTime)
+        
+        val filtered = allTelemetry.filter { 
+            it.success && 
+            (userEmail == null || it.email.equals(userEmail, ignoreCase = true))
+        }
+        
+        val dateFormat = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.getDefault())
+        Log.d(TAG, "📥 Login telemetry: ${allTelemetry.size} total in range, ${filtered.size} filtered " +
+                "(email=$userEmail, periodStart=${dateFormat.format(java.util.Date(periodStartTimestamp))}, " +
+                "periodEnd=${dateFormat.format(java.util.Date(endTime))})")
+        
+        filtered
+    }
+    
+    /**
+     * Obtiene todas las operaciones del usuario en el período.
+     * Nota: OutboxEntity no tiene userId directo en el payload.
+     * Por ahora, obtenemos todas las operaciones no sincronizadas en el período.
+     */
+    private suspend fun getAllOutboxOperations(
+        userId: String,
+        periodStartTimestamp: Long
+    ): List<OutboxEntity> = withContext(Dispatchers.IO) {
+        val allOperations = outboxDao.getUnsyncedOperations()
+        val filtered = allOperations.filter { it.createdAt >= periodStartTimestamp }
+        
+        Log.d(TAG, "📥 Outbox operations: ${allOperations.size} total, ${filtered.size} filtered " +
+                "(periodStart=${java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.getDefault()).format(java.util.Date(periodStartTimestamp))})")
+        
+        filtered
+    }
+    
+    /**
+     * Obtiene todas las búsquedas del usuario en el período.
+     */
+    private suspend fun getAllSearchHistory(
+        userId: String,
+        periodStartTimestamp: Long
+    ): List<SearchHistoryEntity> = withContext(Dispatchers.IO) {
+        val allSearches = libraryCacheDao.getRecentSearches(userId, limit = 1000)
+        val filtered = allSearches.filter { it.timestamp >= periodStartTimestamp }
+        
+        Log.d(TAG, "📥 Search history: ${allSearches.size} total, ${filtered.size} filtered " +
+                "(userId=$userId, periodStart=${java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.getDefault()).format(java.util.Date(periodStartTimestamp))})")
+        
+        filtered
+    }
+    
+    /**
+     * Agrupa eventos por sesión y calcula métricas.
+     * Una sesión comienza con un login exitoso y termina después de 30 minutos de inactividad.
+     */
+    private fun groupEventsBySession(
+        userId: String,
+        loginTelemetry: List<LoginTelemetryEntity>,
+        outboxOperations: List<OutboxEntity>,
+        searchHistory: List<SearchHistoryEntity>
+    ): List<SessionActivityLogEntity> {
+        
+        if (loginTelemetry.isEmpty()) {
+            Log.d(TAG, "No login telemetry found, returning empty logs")
+            return emptyList()
+        }
+        
+        // Ordenar logins por timestamp
+        val sortedLogins = loginTelemetry.sortedBy { it.timestamp }
+        
+        val sessionLogs = mutableListOf<SessionActivityLogEntity>()
+        
+        for (login in sortedLogins) {
+            val sessionStart = login.timestamp
+            val sessionEnd = sessionStart + SessionActivityLogEntity.SESSION_INACTIVITY_WINDOW_MS
+            
+            // Encontrar todos los eventos que pertenecen a esta sesión
+            val sessionOutboxOps = outboxOperations.filter { op ->
+                op.createdAt >= sessionStart && 
+                op.createdAt <= sessionEnd
+            }
+            
+            val sessionSearches = searchHistory.filter { search ->
+                search.timestamp >= sessionStart && 
+                search.timestamp <= sessionEnd
+            }
+            
+            // Calcular métricas
+            val totalActions = sessionOutboxOps.size
+            val actionTypesMap = sessionOutboxOps
+                .groupingBy { it.operationType.name }
+                .eachCount()
+            val actionTypesJson = gson.toJson(actionTypesMap)
+            
+            val totalSearches = sessionSearches.size
+            val searchQueries = sessionSearches
+                .sortedByDescending { it.timestamp }
+                .take(10) // Limitar a 10 búsquedas más recientes
+                .map { it.query }
+            val searchQueriesJson = gson.toJson(searchQueries)
+            
+            // Calcular duración de sesión
+            val lastEventTimestamp = listOfNotNull(
+                sessionOutboxOps.maxOfOrNull { it.createdAt },
+                sessionSearches.maxOfOrNull { it.timestamp }
+            ).maxOrNull() ?: sessionStart
+            
+            val actualSessionEnd = lastEventTimestamp + SessionActivityLogEntity.SESSION_INACTIVITY_WINDOW_MS
+            val durationMinutes = ((actualSessionEnd - sessionStart) / (60 * 1000)).toInt()
+            
+            // Crear log de sesión
+            val sessionLog = SessionActivityLogEntity(
+                userId = userId,
+                sessionStartTimestamp = sessionStart,
+                sessionEndTimestamp = actualSessionEnd,
+                durationMinutes = durationMinutes,
+                loginType = login.loginType.name,
+                totalActions = totalActions,
+                actionTypesJson = actionTypesJson,
+                totalSearches = totalSearches,
+                searchQueriesJson = searchQueriesJson,
+                processedAt = System.currentTimeMillis(),
+                cachedAt = System.currentTimeMillis(),
+                expiresAt = SessionActivityLogEntity.calculateExpiresAt()
+            )
+            
+            sessionLogs.add(sessionLog)
+        }
+        
+        Log.d(TAG, "✅ Processed ${sessionLogs.size} session logs")
+        return sessionLogs
+    }
+    
+    /**
+     * Limpia logs expirados para liberar espacio.
+     * Debe llamarse periódicamente.
+     */
+    suspend fun cleanupExpiredLogs() {
+        withContext(Dispatchers.IO) {
+            sessionLogDao.deleteExpiredLogs()
+            Log.d(TAG, "🧹 Cleaned up expired session logs")
+        }
+    }
+    
+    /**
+     * Elimina todos los logs de un usuario.
+     * Útil para limpieza de datos o logout.
+     */
+    suspend fun deleteAllLogsForUser(userId: String) {
+        withContext(Dispatchers.IO) {
+            sessionLogDao.deleteAllLogsForUser(userId)
+            Log.d(TAG, "🗑️ Deleted all logs for user: $userId")
+        }
+    }
+}
+

--- a/app/src/main/java/com/g22/orbitsoundkotlin/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/ui/screens/home/HomeScreen.kt
@@ -47,7 +47,8 @@ fun HomeScreen(
     user: AuthUser,
     onNavigateToStellarEmotions: () -> Unit,
     onNavigateToLibrary: () -> Unit = {},
-    onNavigateToProfile: () -> Unit = {}
+    onNavigateToProfile: () -> Unit = {},
+    onNavigateToCaptainsLog: () -> Unit = {}
 ) {
     val context = LocalContext.current
     // ✅ CONECTIVIDAD EVENTUAL: Inyectar Context al HomeViewModel
@@ -199,6 +200,7 @@ fun HomeScreen(
                     when (shortcut.label) {
                         "Stellar Emotions" -> onNavigateToStellarEmotions()
                         "Star Archive" -> onNavigateToLibrary()
+                        "Captain's Log" -> onNavigateToCaptainsLog()
                         "Command profile" -> onNavigateToProfile()
                     }
                 }

--- a/app/src/main/java/com/g22/orbitsoundkotlin/ui/viewmodels/CaptainsLogViewModel.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/ui/viewmodels/CaptainsLogViewModel.kt
@@ -1,0 +1,242 @@
+package com.g22.orbitsoundkotlin.ui.viewmodels
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.g22.orbitsoundkotlin.data.local.entities.SessionActivityLogEntity
+import com.g22.orbitsoundkotlin.data.repositories.SessionActivityRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * ViewModel para Captain's Log - Session Activity Journal.
+ * 
+ * Procesa y muestra logs de actividad de sesiones del usuario.
+ * Implementa cache en memoria y procesamiento paralelo para múltiples períodos.
+ */
+data class CaptainsLogUiState(
+    val isLoading: Boolean = false,
+    val sessionLogs: List<SessionActivityLogEntity> = emptyList(),
+    val error: String? = null,
+    val selectedPeriod: ActivityPeriod = ActivityPeriod.WEEK
+)
+
+/**
+ * Períodos de actividad disponibles para filtrar logs.
+ */
+enum class ActivityPeriod(val days: Int, val displayName: String) {
+    DAY(1, "Día"),
+    WEEK(7, "Semana"),
+    MONTH(30, "Mes")
+}
+
+class CaptainsLogViewModel(
+    private val sessionActivityRepository: SessionActivityRepository,
+    private val userId: String,
+    private val userEmail: String? = null
+) : ViewModel() {
+    
+    private val _uiState = MutableStateFlow(CaptainsLogUiState())
+    val uiState: StateFlow<CaptainsLogUiState> = _uiState.asStateFlow()
+    
+    // Cache en memoria para acceso rápido
+    private val memoryCache = mutableMapOf<String, List<SessionActivityLogEntity>>()
+    private val TAG = "CaptainsLogViewModel"
+    
+    init {
+        // Cargar logs al inicializar
+        loadSessionLogs(ActivityPeriod.WEEK)
+    }
+    
+    /**
+     * Carga logs de sesiones para un período específico.
+     * Usa cache en memoria si está disponible, sino procesa en background.
+     */
+    fun loadSessionLogs(period: ActivityPeriod) {
+        if (userId.isBlank()) {
+            _uiState.update { it.copy(error = "User ID is required") }
+            return
+        }
+        
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null, selectedPeriod = period) }
+            
+            try {
+                // Paso 1: Verificar cache en memoria (acceso ultra-rápido)
+                val cacheKey = "${userId}_${period.name}"
+                val cachedInMemory = memoryCache[cacheKey]
+                if (cachedInMemory != null) {
+                    Log.d(TAG, "✅ Memory cache HIT for period: ${period.displayName}")
+                    _uiState.update {
+                        it.copy(
+                            sessionLogs = cachedInMemory,
+                            isLoading = false
+                        )
+                    }
+                    // Actualizar en background sin bloquear UI
+                    refreshLogsInBackground(period)
+                    return@launch
+                }
+                
+                // Paso 2: Obtener desde repositorio (cache Room + procesamiento)
+                val periodStartTimestamp = System.currentTimeMillis() - (period.days * 24 * 60 * 60 * 1000L)
+                val logs = withContext(Dispatchers.Default) {
+                    // Procesamiento en background thread para no bloquear UI
+                    sessionActivityRepository.getSessionLogs(userId, userEmail, periodStartTimestamp)
+                }
+                
+                // Paso 3: Actualizar cache en memoria y UI
+                memoryCache[cacheKey] = logs
+                _uiState.update {
+                    it.copy(
+                        sessionLogs = logs,
+                        isLoading = false
+                    )
+                }
+                
+                Log.d(TAG, "✅ Session logs loaded for ${period.displayName}: ${logs.size} sessions")
+                
+            } catch (e: Exception) {
+                Log.e(TAG, "❌ Error loading session logs", e)
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = e.message ?: "Error loading session logs"
+                    )
+                }
+            }
+        }
+    }
+    
+    /**
+     * Carga logs para múltiples períodos en paralelo.
+     * Útil para mostrar comparaciones o estadísticas agregadas.
+     */
+    fun loadAllPeriodsLogs() {
+        if (userId.isBlank()) {
+            _uiState.update { it.copy(error = "User ID is required") }
+            return
+        }
+        
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            
+            try {
+                // Procesamiento paralelo de múltiples períodos
+                val dayDeferred = async(Dispatchers.Default) {
+                    val periodStart = System.currentTimeMillis() - (ActivityPeriod.DAY.days * 24 * 60 * 60 * 1000L)
+                    sessionActivityRepository.getSessionLogs(userId, userEmail, periodStart)
+                }
+                
+                val weekDeferred = async(Dispatchers.Default) {
+                    val periodStart = System.currentTimeMillis() - (ActivityPeriod.WEEK.days * 24 * 60 * 60 * 1000L)
+                    sessionActivityRepository.getSessionLogs(userId, userEmail, periodStart)
+                }
+                
+                val monthDeferred = async(Dispatchers.Default) {
+                    val periodStart = System.currentTimeMillis() - (ActivityPeriod.MONTH.days * 24 * 60 * 60 * 1000L)
+                    sessionActivityRepository.getSessionLogs(userId, userEmail, periodStart)
+                }
+                
+                // Esperar a que todos los períodos se procesen (await individual para mantener tipos)
+                val dayLogs = dayDeferred.await()
+                val weekLogs = weekDeferred.await()
+                val monthLogs = monthDeferred.await()
+                
+                // Actualizar cache en memoria
+                memoryCache["${userId}_${ActivityPeriod.DAY.name}"] = dayLogs
+                memoryCache["${userId}_${ActivityPeriod.WEEK.name}"] = weekLogs
+                memoryCache["${userId}_${ActivityPeriod.MONTH.name}"] = monthLogs
+                
+                // Mostrar logs de la semana por defecto
+                _uiState.update {
+                    it.copy(
+                        sessionLogs = weekLogs,
+                        isLoading = false,
+                        selectedPeriod = ActivityPeriod.WEEK
+                    )
+                }
+                
+                Log.d(TAG, "✅ All periods loaded in parallel: " +
+                        "Day=${dayLogs.size}, Week=${weekLogs.size}, Month=${monthLogs.size}")
+                
+            } catch (e: Exception) {
+                Log.e(TAG, "❌ Error loading all periods logs", e)
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = e.message ?: "Error loading session logs"
+                    )
+                }
+            }
+        }
+    }
+    
+    /**
+     * Actualiza logs en background sin bloquear UI.
+     * Útil para refrescar datos después de servir cache.
+     */
+    private fun refreshLogsInBackground(period: ActivityPeriod) {
+        viewModelScope.launch(Dispatchers.Default) {
+            try {
+                val periodStartTimestamp = System.currentTimeMillis() - (period.days * 24 * 60 * 60 * 1000L)
+                val logs = sessionActivityRepository.getSessionLogs(userId, userEmail, periodStartTimestamp)
+                
+                // Actualizar cache en memoria
+                val cacheKey = "${userId}_${period.name}"
+                memoryCache[cacheKey] = logs
+                
+                // Actualizar UI si el período sigue siendo el seleccionado
+                _uiState.update { currentState ->
+                    if (currentState.selectedPeriod == period) {
+                        currentState.copy(sessionLogs = logs)
+                    } else {
+                        currentState
+                    }
+                }
+                
+                Log.d(TAG, "🔄 Background refresh completed for ${period.displayName}")
+            } catch (e: Exception) {
+                Log.e(TAG, "❌ Error refreshing logs in background", e)
+            }
+        }
+    }
+    
+    /**
+     * Limpia el cache en memoria.
+     * Útil cuando el usuario cambia o se necesita forzar recarga.
+     */
+    fun clearMemoryCache() {
+        memoryCache.clear()
+        Log.d(TAG, "🗑️ Memory cache cleared")
+    }
+    
+    /**
+     * Limpia todos los logs del usuario (cache y datos).
+     * Útil para logout o limpieza de datos.
+     */
+    fun clearAllLogs() {
+        viewModelScope.launch {
+            try {
+                sessionActivityRepository.deleteAllLogsForUser(userId)
+                memoryCache.clear()
+                _uiState.update {
+                    it.copy(sessionLogs = emptyList())
+                }
+                Log.d(TAG, "🗑️ All logs cleared for user")
+            } catch (e: Exception) {
+                Log.e(TAG, "❌ Error clearing logs", e)
+                _uiState.update {
+                    it.copy(error = e.message ?: "Error clearing logs")
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/g22/orbitsoundkotlin/ui/viewmodels/CaptainsLogViewModelFactory.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/ui/viewmodels/CaptainsLogViewModelFactory.kt
@@ -1,0 +1,33 @@
+package com.g22.orbitsoundkotlin.ui.viewmodels
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.g22.orbitsoundkotlin.data.local.AppDatabase
+import com.g22.orbitsoundkotlin.data.repositories.SessionActivityRepository
+
+/**
+ * Factory para crear CaptainsLogViewModel con dependencias inyectadas.
+ * 
+ * Inyecta:
+ * - SessionActivityRepository (con acceso a Room Database)
+ * - userId (del usuario autenticado)
+ * - userEmail (email del usuario autenticado, opcional)
+ */
+class CaptainsLogViewModelFactory(
+    private val context: Context,
+    private val userId: String,
+    private val userEmail: String? = null
+) : ViewModelProvider.Factory {
+    
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(CaptainsLogViewModel::class.java)) {
+            val database = AppDatabase.getInstance(context)
+            val repository = SessionActivityRepository(database)
+            return CaptainsLogViewModel(repository, userId, userEmail) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}
+


### PR DESCRIPTION
This commit introduces the "Captain's Log" feature, a user session activity journal that works offline by processing local data.

- **Data Layer:**
    - Added `SessionActivityLogEntity` to Room to store aggregated session metrics.
    - Implemented `SessionActivityLogDao` with indexed queries for efficient data retrieval.
    - Created `SessionActivityRepository` to process and aggregate login telemetry, user actions, and search history into distinct user sessions. It uses a Stale-While-Revalidate (SWR) caching strategy for performance.

- **ViewModel:**
    - Introduced `CaptainsLogViewModel` to manage the UI state for the session log.
    - Implemented in-memory caching and parallel data processing for different time periods (day, week, month).
    - Added `CaptainsLogViewModelFactory` for dependency injection.

- **UI & Navigation:**
    - Added a navigation route to the "Captain's Log" screen.
    - Included a temporary placeholder UI in `MainActivity` to test and verify the feature's data processing pipeline.