### PR TITLE
refactor: Rename "Captain's Log" to "Activity Stats"

### DIFF
--- a/app/src/main/java/com/g22/orbitsoundkotlin/MainActivity.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/MainActivity.kt
@@ -441,7 +441,7 @@ private fun OrbitSoundApp() {
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         androidx.compose.material3.Text(
-                            text = "Captain's Log - Feature Test",
+                            text = "Activity Stats - Feature Test",
                             style = androidx.compose.material3.MaterialTheme.typography.headlineMedium,
                             color = androidx.compose.ui.graphics.Color.White,
                             modifier = Modifier.padding(bottom = 16.dp)

--- a/app/src/main/java/com/g22/orbitsoundkotlin/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/ui/screens/home/HomeScreen.kt
@@ -192,7 +192,7 @@ fun HomeScreen(
                 items = listOf(
                     ShortcutSpec("Stellar Emotions", R.drawable.stellar_emotions),
                     ShortcutSpec("Star Archive", R.drawable.star_archive),
-                    ShortcutSpec("Captain's Log", R.drawable.captain_log),
+                    ShortcutSpec("Activity Stats", R.drawable.captain_log),
                     ShortcutSpec("Crew members", R.drawable.crew_members),
                     ShortcutSpec("Command profile", R.drawable.command_profile)
                 ),
@@ -200,7 +200,7 @@ fun HomeScreen(
                     when (shortcut.label) {
                         "Stellar Emotions" -> onNavigateToStellarEmotions()
                         "Star Archive" -> onNavigateToLibrary()
-                        "Captain's Log" -> onNavigateToCaptainsLog()
+                        "Activity Stats" -> onNavigateToCaptainsLog()
                         "Command profile" -> onNavigateToProfile()
                     }
                 }


### PR DESCRIPTION
The feature previously known as "Captain's Log" has been renamed to "Activity Stats" across the user interface to better reflect its purpose. This includes updating the screen title and the shortcut label on the home screen.

Issue: #95 