### PR TITLE
feat: Implement full CRUD functionality for Journal

### DIFF
--- a/app/src/main/java/com/g22/orbitsoundkotlin/ui/screens/activitystats/ActivityStatsScreen.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/ui/screens/activitystats/ActivityStatsScreen.kt
@@ -1,6 +1,7 @@
 package com.g22.orbitsoundkotlin.ui.screens.activitystats
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,6 +11,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -17,26 +20,40 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material.icons.outlined.MusicNote
 import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.ChevronLeft
+import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -53,6 +70,7 @@ import kotlinx.coroutines.launch
 /**
  * Pantalla principal de Activity Stats (una vez desbloqueada).
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ActivityStatsScreen(
     onBack: () -> Unit,
@@ -62,71 +80,111 @@ fun ActivityStatsScreen(
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
-    
-    // Mostrar snackbar cuando se guarda el diario
-    LaunchedEffect(uiState.journalSaved) {
-        if (uiState.journalSaved) {
-            coroutineScope.launch {
-                snackbarHostState.showSnackbar("Journal saved for today.")
-                viewModel.clearJournalSavedMessage()
-            }
-        }
-    }
+    var selectedEntryForView by remember { mutableStateOf<com.g22.orbitsoundkotlin.ui.viewmodels.JournalEntry?>(null) }
+    val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
-        containerColor = Color(0xFF010B19)
+        containerColor = Color(0xFF010B19),
+        topBar = {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = "Back",
+                        tint = Color.White
+                    )
+                }
+            }
+        }
     ) { paddingValues ->
-        Column(
-            modifier = modifier
-                .fillMaxSize()
-                .background(Color(0xFF010B19))
-                .padding(paddingValues)
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 20.dp, vertical = 20.dp)
-        ) {
-            // Header
-            ActivityStatsHeader(
-                selectedPeriod = uiState.selectedPeriod,
-                onPeriodSelected = viewModel::selectPeriod
-            )
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = modifier
+                    .fillMaxSize()
+                    .background(Color(0xFF010B19))
+                    .padding(paddingValues)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 20.dp, vertical = 20.dp)
+            ) {
+                // Header
+                ActivityStatsHeader(
+                    selectedPeriod = uiState.selectedPeriod,
+                    onPeriodSelected = viewModel::selectPeriod
+                )
+                
+                Spacer(modifier = Modifier.height(24.dp))
+                
+                // Stats Summary Cards
+                ActivityStatsSummaryCards(
+                    sessionsCount = uiState.sessionsCount,
+                    totalTimeMinutes = uiState.totalTimeMinutes,
+                    mostCommonAction = uiState.mostCommonAction
+                )
+                
+                Spacer(modifier = Modifier.height(24.dp))
+                
+                // Recent Activity Section
+                RecentActivitySection(
+                    activities = uiState.recentActivities
+                )
+                
+                Spacer(modifier = Modifier.height(24.dp))
+                
+                // Journal Section (completo)
+                JournalSection(
+                    uiState = uiState,
+                    viewModel = viewModel,
+                    onEntryClick = { entry ->
+                        selectedEntryForView = entry
+                    }
+                )
+                
+                Spacer(modifier = Modifier.height(24.dp))
+            }
             
-            Spacer(modifier = Modifier.height(24.dp))
+            // Editor de entrada (nuevo/editar)
+            if (uiState.isEditingEntry) {
+                JournalEntryEditor(
+                    text = uiState.editorText,
+                    characterCount = uiState.editorCharacterCount,
+                    maxCharacters = uiState.maxJournalCharacters,
+                    isSaving = uiState.isSavingEntry,
+                    onTextChange = viewModel::updateEditorText,
+                    onSave = viewModel::saveEntry,
+                    onCancel = viewModel::closeEntryEditor
+                )
+            }
             
-            // Stats Summary Cards
-            ActivityStatsSummaryCards(
-                sessionsCount = uiState.sessionsCount,
-                totalTimeMinutes = uiState.totalTimeMinutes,
-                mostCommonAction = uiState.mostCommonAction
-            )
-            
-            Spacer(modifier = Modifier.height(24.dp))
-            
-            // Recent Activity Section
-            RecentActivitySection(
-                activities = uiState.recentActivities
-            )
-            
-            Spacer(modifier = Modifier.height(24.dp))
-            
-            // Today's Journal Section
-            TodaysJournalSection(
-                journalText = uiState.todaysJournalText,
-                characterCount = uiState.journalCharacterCount,
-                maxCharacters = uiState.maxJournalCharacters,
-                isSaving = uiState.isSavingJournal,
-                onTextChange = viewModel::updateJournalText,
-                onSave = viewModel::saveTodaysJournal
-            )
-            
-            Spacer(modifier = Modifier.height(24.dp))
-            
-            // Previous Entries Section
-            PreviousEntriesSection(
-                entries = uiState.previousEntries
-            )
-            
-            Spacer(modifier = Modifier.height(24.dp))
+            // Bottom sheet para ver entrada completa
+            if (selectedEntryForView != null) {
+                ModalBottomSheet(
+                    onDismissRequest = { selectedEntryForView = null },
+                    sheetState = bottomSheetState,
+                    containerColor = Color(0xFF24292E)
+                ) {
+                    JournalEntryBottomSheet(
+                        entry = selectedEntryForView!!,
+                        onEdit = { entry ->
+                            selectedEntryForView = null
+                            viewModel.openEditEntryEditor(entry.id)
+                        },
+                        onDelete = { entry ->
+                            selectedEntryForView = null
+                            viewModel.deleteEntry(entry.id)
+                            coroutineScope.launch {
+                                snackbarHostState.showSnackbar("Entry deleted")
+                            }
+                        },
+                        onDismiss = { selectedEntryForView = null }
+                    )
+                }
+            }
         }
     }
 }
@@ -240,141 +298,456 @@ private fun RecentActivitySection(
 }
 
 @Composable
-private fun TodaysJournalSection(
-    journalText: String,
-    characterCount: Int,
-    maxCharacters: Int,
-    isSaving: Boolean,
-    onTextChange: (String) -> Unit,
-    onSave: () -> Unit
+private fun JournalSection(
+    uiState: com.g22.orbitsoundkotlin.ui.viewmodels.ActivityStatsUiState,
+    viewModel: ActivityStatsViewModel,
+    onEntryClick: (com.g22.orbitsoundkotlin.ui.viewmodels.JournalEntry) -> Unit
 ) {
     Column {
-        Text(
-            text = "Today's Journal",
-            style = TextStyle(
-                fontSize = 18.sp,
-                fontWeight = FontWeight.Bold,
-                color = Color.White
-            )
-        )
-        
-        Spacer(modifier = Modifier.height(4.dp))
-        
-        Text(
-            text = "Write a short reflection about today.",
-            style = TextStyle(
-                fontSize = 12.sp,
-                color = Color.White.copy(alpha = 0.7f)
-            )
-        )
-        
-        Spacer(modifier = Modifier.height(12.dp))
-        
-        TextField(
-            value = journalText,
-            onValueChange = onTextChange,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(120.dp),
-            placeholder = {
-                Text(
-                    text = "Today I discovered new tracks that helped me focus…",
-                    color = Color.White.copy(alpha = 0.5f)
-                )
-            },
-            colors = TextFieldDefaults.colors(
-                focusedTextColor = Color.White,
-                unfocusedTextColor = Color.White,
-                focusedContainerColor = Color(0xFF24292E),
-                unfocusedContainerColor = Color(0xFF24292E),
-                focusedIndicatorColor = Color(0xFF5099BA),
-                unfocusedIndicatorColor = Color(0xFF5099BA).copy(alpha = 0.5f),
-                cursorColor = Color(0xFF5099BA)
-            ),
-            textStyle = TextStyle(
-                fontSize = 14.sp,
-                color = Color.White,
-                lineHeight = 20.sp
-            ),
-            maxLines = 5
-        )
-        
-        Spacer(modifier = Modifier.height(4.dp))
-        
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "$characterCount/$maxCharacters",
+                text = "Journal",
                 style = TextStyle(
-                    fontSize = 11.sp,
-                    color = Color.White.copy(alpha = 0.6f)
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White
                 )
             )
             
             Button(
-                onClick = onSave,
-                enabled = journalText.trim().isNotEmpty() && !isSaving,
+                onClick = { viewModel.openNewEntryEditor() },
                 colors = ButtonDefaults.buttonColors(
                     containerColor = Color(0xFF5099BA),
                     contentColor = Color.White
+                ),
+                modifier = Modifier.height(36.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Add,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
                 )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text("New entry", style = TextStyle(fontSize = 12.sp))
+            }
+        }
+        
+        Spacer(modifier = Modifier.height(16.dp))
+        
+        // Selector de día
+        JournalDateSelector(
+            selectedDate = uiState.selectedDate,
+            availableDates = uiState.availableDates,
+            onPreviousDay = { viewModel.navigateToPreviousDay() },
+            onNextDay = { viewModel.navigateToNextDay() }
+        )
+        
+        Spacer(modifier = Modifier.height(16.dp))
+        
+        // Lista de entradas del día
+        JournalEntriesList(
+            entries = uiState.entriesOfSelectedDate,
+            onEntryClick = onEntryClick,
+            onEdit = { viewModel.openEditEntryEditor(it.id) },
+            onDelete = { entry ->
+                viewModel.deleteEntry(entry.id)
+            }
+        )
+    }
+}
+
+@Composable
+private fun JournalDateSelector(
+    selectedDate: Long,
+    availableDates: List<Long>,
+    onPreviousDay: () -> Unit,
+    onNextDay: () -> Unit
+) {
+    val calendar = java.util.Calendar.getInstance()
+    calendar.timeInMillis = selectedDate
+    val today = java.util.Calendar.getInstance()
+    val yesterday = java.util.Calendar.getInstance().apply {
+        add(java.util.Calendar.DAY_OF_YEAR, -1)
+    }
+    
+    val dateText = when {
+        isSameDay(calendar, today) -> "Today"
+        isSameDay(calendar, yesterday) -> "Yesterday"
+        else -> {
+            val dayOfWeek = calendar.get(java.util.Calendar.DAY_OF_WEEK)
+            val month = calendar.get(java.util.Calendar.MONTH)
+            val day = calendar.get(java.util.Calendar.DAY_OF_MONTH)
+            val dayNames = arrayOf("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
+            val monthNames = arrayOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+            "${dayNames[dayOfWeek - 1]} · ${monthNames[month]} $day"
+        }
+    }
+    
+    val sortedDates = availableDates.sorted()
+    val currentIndex = sortedDates.indexOf(selectedDate)
+    val canGoPrevious = currentIndex > 0
+    val canGoNext = currentIndex >= 0 && currentIndex < sortedDates.size - 1
+    
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(
+            onClick = onPreviousDay,
+            enabled = canGoPrevious
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.ChevronLeft,
+                contentDescription = "Previous day",
+                tint = if (canGoPrevious) Color(0xFF5099BA) else Color.White.copy(alpha = 0.3f)
+            )
+        }
+        
+        Text(
+            text = dateText,
+            style = TextStyle(
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.White
+            )
+        )
+        
+        IconButton(
+            onClick = onNextDay,
+            enabled = canGoNext
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.ChevronRight,
+                contentDescription = "Next day",
+                tint = if (canGoNext) Color(0xFF5099BA) else Color.White.copy(alpha = 0.3f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun JournalEntriesList(
+    entries: List<com.g22.orbitsoundkotlin.ui.viewmodels.JournalEntry>,
+    onEntryClick: (com.g22.orbitsoundkotlin.ui.viewmodels.JournalEntry) -> Unit,
+    onEdit: (com.g22.orbitsoundkotlin.ui.viewmodels.JournalEntry) -> Unit,
+    onDelete: (com.g22.orbitsoundkotlin.ui.viewmodels.JournalEntry) -> Unit
+) {
+    if (entries.isEmpty()) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = Color(0xFF24292E)
+            ),
+            shape = RoundedCornerShape(12.dp)
+        ) {
+            Text(
+                text = "No entries for this day. Tap \"+ New entry\" to create one.",
+                modifier = Modifier.padding(16.dp),
+                style = TextStyle(
+                    fontSize = 14.sp,
+                    color = Color.White.copy(alpha = 0.6f)
+                )
+            )
+        }
+    } else {
+        entries.forEach { entry ->
+            JournalEntryListItem(
+                entry = entry,
+                onClick = { onEntryClick(entry) },
+                onEdit = { onEdit(entry) },
+                onDelete = { onDelete(entry) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun JournalEntryListItem(
+    entry: com.g22.orbitsoundkotlin.ui.viewmodels.JournalEntry,
+    onClick: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = Color(0xFF24292E)
+        ),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = if (isSaving) "Saving..." else "Save entry",
-                    style = TextStyle(fontSize = 14.sp)
+                    text = entry.time,
+                    style = TextStyle(
+                        fontSize = 11.sp,
+                        color = Color.White.copy(alpha = 0.6f)
+                    )
                 )
+                
+                Row {
+                    IconButton(
+                        onClick = onEdit,
+                        modifier = Modifier.size(32.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Edit,
+                            contentDescription = "Edit",
+                            tint = Color(0xFF5099BA),
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                    
+                    IconButton(
+                        onClick = onDelete,
+                        modifier = Modifier.size(32.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Delete,
+                            contentDescription = "Delete",
+                            tint = Color(0xFFFF5252),
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                }
+            }
+            
+            Spacer(modifier = Modifier.height(8.dp))
+            
+            Text(
+                text = if (entry.text.length > 150) {
+                    entry.text.take(150) + "..."
+                } else {
+                    entry.text
+                },
+                style = TextStyle(
+                    fontSize = 14.sp,
+                    color = Color.White.copy(alpha = 0.9f),
+                    lineHeight = 20.sp
+                ),
+                modifier = Modifier.clickable(onClick = onClick),
+                maxLines = 4
+            )
+        }
+    }
+}
+
+@Composable
+private fun JournalEntryEditor(
+    text: String,
+    characterCount: Int,
+    maxCharacters: Int,
+    isSaving: Boolean,
+    onTextChange: (String) -> Unit,
+    onSave: () -> Unit,
+    onCancel: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.7f))
+            .clickable(onClick = onCancel),
+        contentAlignment = Alignment.Center
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = Color(0xFF24292E)
+            ),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(20.dp)
+            ) {
+                Text(
+                    text = if (text.isEmpty()) "New Entry" else "Edit Entry",
+                    style = TextStyle(
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
+                    )
+                )
+                
+                Spacer(modifier = Modifier.height(16.dp))
+                
+                TextField(
+                    value = text,
+                    onValueChange = onTextChange,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    placeholder = {
+                        Text(
+                            text = "Write your thoughts...",
+                            color = Color.White.copy(alpha = 0.5f)
+                        )
+                    },
+                    colors = TextFieldDefaults.colors(
+                        focusedTextColor = Color.White,
+                        unfocusedTextColor = Color.White,
+                        focusedContainerColor = Color(0xFF010B19),
+                        unfocusedContainerColor = Color(0xFF010B19),
+                        focusedIndicatorColor = Color(0xFF5099BA),
+                        unfocusedIndicatorColor = Color(0xFF5099BA).copy(alpha = 0.5f),
+                        cursorColor = Color(0xFF5099BA)
+                    ),
+                    textStyle = TextStyle(
+                        fontSize = 14.sp,
+                        color = Color.White,
+                        lineHeight = 20.sp
+                    ),
+                    maxLines = 10
+                )
+                
+                Spacer(modifier = Modifier.height(8.dp))
+                
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "$characterCount/$maxCharacters",
+                        style = TextStyle(
+                            fontSize = 11.sp,
+                            color = Color.White.copy(alpha = 0.6f)
+                        )
+                    )
+                    
+                    Row {
+                        TextButton(onClick = onCancel) {
+                            Text("Cancel", color = Color.White.copy(alpha = 0.7f))
+                        }
+                        
+                        Spacer(modifier = Modifier.width(8.dp))
+                        
+                        Button(
+                            onClick = onSave,
+                            enabled = text.trim().isNotEmpty() && !isSaving,
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = Color(0xFF5099BA),
+                                contentColor = Color.White
+                            )
+                        ) {
+                            Text(
+                                text = if (isSaving) "Saving..." else "Save",
+                                style = TextStyle(fontSize = 14.sp)
+                            )
+                        }
+                    }
+                }
             }
         }
     }
 }
 
 @Composable
-private fun PreviousEntriesSection(
-    entries: List<com.g22.orbitsoundkotlin.ui.viewmodels.JournalEntry>
+private fun JournalEntryBottomSheet(
+    entry: com.g22.orbitsoundkotlin.ui.viewmodels.JournalEntry,
+    onEdit: (com.g22.orbitsoundkotlin.ui.viewmodels.JournalEntry) -> Unit,
+    onDelete: (com.g22.orbitsoundkotlin.ui.viewmodels.JournalEntry) -> Unit,
+    onDismiss: () -> Unit
 ) {
-    Column {
-        Text(
-            text = "Previous entries",
-            style = TextStyle(
-                fontSize = 18.sp,
-                fontWeight = FontWeight.Bold,
-                color = Color.White
-            )
-        )
-        
-        Spacer(modifier = Modifier.height(12.dp))
-        
-        if (entries.isEmpty()) {
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = Color(0xFF24292E)
-                ),
-                shape = RoundedCornerShape(12.dp)
-            ) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(24.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column {
                 Text(
-                    text = "You don't have any journal entries yet. Start by writing something about today.",
-                    modifier = Modifier.padding(16.dp),
+                    text = entry.date,
                     style = TextStyle(
                         fontSize = 14.sp,
+                        color = Color.White.copy(alpha = 0.7f)
+                    )
+                )
+                Text(
+                    text = entry.time,
+                    style = TextStyle(
+                        fontSize = 12.sp,
                         color = Color.White.copy(alpha = 0.6f)
                     )
                 )
             }
-        } else {
-            entries.forEach { entry ->
-                JournalEntryCard(
-                    entry = entry,
-                    onClick = {
-                        // TODO: Abrir bottom sheet con entrada completa
-                    }
-                )
+            
+            Row {
+                TextButton(onClick = { onEdit(entry) }) {
+                    Icon(
+                        imageVector = Icons.Outlined.Edit,
+                        contentDescription = null,
+                        tint = Color(0xFF5099BA),
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text("Edit", color = Color(0xFF5099BA))
+                }
+                
+                TextButton(onClick = { onDelete(entry) }) {
+                    Icon(
+                        imageVector = Icons.Outlined.Delete,
+                        contentDescription = null,
+                        tint = Color(0xFFFF5252),
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text("Delete", color = Color(0xFFFF5252))
+                }
             }
         }
+        
+        Spacer(modifier = Modifier.height(16.dp))
+        
+        Text(
+            text = entry.text,
+            style = TextStyle(
+                fontSize = 14.sp,
+                color = Color.White,
+                lineHeight = 22.sp
+            )
+        )
+        
+        Spacer(modifier = Modifier.height(16.dp))
+        
+        Button(
+            onClick = onDismiss,
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color(0xFF5099BA),
+                contentColor = Color.White
+            )
+        ) {
+            Text("Close")
+        }
     }
+}
+
+private fun isSameDay(cal1: java.util.Calendar, cal2: java.util.Calendar): Boolean {
+    return cal1.get(java.util.Calendar.YEAR) == cal2.get(java.util.Calendar.YEAR) &&
+            cal1.get(java.util.Calendar.DAY_OF_YEAR) == cal2.get(java.util.Calendar.DAY_OF_YEAR)
 }
 
 /**

--- a/app/src/main/java/com/g22/orbitsoundkotlin/ui/viewmodels/ActivityStatsViewModel.kt
+++ b/app/src/main/java/com/g22/orbitsoundkotlin/ui/viewmodels/ActivityStatsViewModel.kt
@@ -27,15 +27,18 @@ data class ActivityStatsUiState(
     // Recent activity (dummy data por ahora)
     val recentActivities: List<ActivityItem> = emptyList(),
     
-    // Today's journal
-    val todaysJournalText: String = "",
-    val journalCharacterCount: Int = 0,
-    val maxJournalCharacters: Int = 300,
-    val isSavingJournal: Boolean = false,
-    val journalSaved: Boolean = false,
+    // Journal state
+    val selectedDate: Long = System.currentTimeMillis(), // Timestamp del día seleccionado
+    val entriesOfSelectedDate: List<JournalEntry> = emptyList(),
+    val availableDates: List<Long> = emptyList(), // Fechas que tienen entradas
     
-    // Previous entries (dummy data por ahora)
-    val previousEntries: List<JournalEntry> = emptyList()
+    // Journal editor state
+    val isEditingEntry: Boolean = false,
+    val editingEntryId: String? = null,
+    val editorText: String = "",
+    val editorCharacterCount: Int = 0,
+    val maxJournalCharacters: Int = 300,
+    val isSavingEntry: Boolean = false
 )
 
 /**
@@ -64,7 +67,8 @@ data class JournalEntry(
     val id: String,
     val date: String, // Formato: "Mon · Nov 24"
     val text: String,
-    val timestamp: Long
+    val timestamp: Long,
+    val time: String // Formato: "8:03 PM"
 )
 
 class ActivityStatsViewModel : ViewModel() {
@@ -72,9 +76,13 @@ class ActivityStatsViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(ActivityStatsUiState())
     val uiState: StateFlow<ActivityStatsUiState> = _uiState.asStateFlow()
     
+    // Dummy storage: mapa de fecha (timestamp del inicio del día) -> lista de entradas
+    private val journalEntriesByDate = mutableMapOf<Long, MutableList<JournalEntry>>()
+    
     init {
         // TODO: Cargar datos reales desde Repository cuando se implemente la FEATURE
         loadDummyData()
+        initializeDummyJournalEntries()
     }
     
     /**
@@ -87,45 +95,301 @@ class ActivityStatsViewModel : ViewModel() {
     }
     
     /**
-     * Actualiza el texto del diario de hoy.
+     * Selecciona una fecha para mostrar sus entradas.
      */
-    fun updateJournalText(text: String) {
-        val trimmed = text.take(300) // Limitar a 300 caracteres
+    fun selectDate(dateTimestamp: Long) {
+        val dayStart = getDayStartTimestamp(dateTimestamp)
         _uiState.update {
             it.copy(
-                todaysJournalText = trimmed,
-                journalCharacterCount = trimmed.length,
-                journalSaved = false
+                selectedDate = dayStart,
+                entriesOfSelectedDate = journalEntriesByDate[dayStart]?.toList() ?: emptyList()
             )
         }
     }
     
     /**
-     * Guarda la entrada del diario de hoy.
+     * Navega al día anterior que tenga entradas.
      */
-    fun saveTodaysJournal() {
-        val text = _uiState.value.todaysJournalText.trim()
+    fun navigateToPreviousDay() {
+        val currentDate = _uiState.value.selectedDate
+        val availableDates = _uiState.value.availableDates.sorted()
+        val currentIndex = availableDates.indexOf(currentDate)
+        
+        if (currentIndex > 0) {
+            selectDate(availableDates[currentIndex - 1])
+        }
+    }
+    
+    /**
+     * Navega al día siguiente que tenga entradas.
+     */
+    fun navigateToNextDay() {
+        val currentDate = _uiState.value.selectedDate
+        val availableDates = _uiState.value.availableDates.sorted()
+        val currentIndex = availableDates.indexOf(currentDate)
+        
+        if (currentIndex >= 0 && currentIndex < availableDates.size - 1) {
+            selectDate(availableDates[currentIndex + 1])
+        }
+    }
+    
+    /**
+     * Abre el editor para crear una nueva entrada.
+     */
+    fun openNewEntryEditor() {
+        _uiState.update {
+            it.copy(
+                isEditingEntry = true,
+                editingEntryId = null,
+                editorText = "",
+                editorCharacterCount = 0
+            )
+        }
+    }
+    
+    /**
+     * Abre el editor para editar una entrada existente.
+     */
+    fun openEditEntryEditor(entryId: String) {
+        val entry = _uiState.value.entriesOfSelectedDate.find { it.id == entryId }
+        entry?.let {
+            _uiState.update {
+                it.copy(
+                    isEditingEntry = true,
+                    editingEntryId = entryId,
+                    editorText = entry.text,
+                    editorCharacterCount = entry.text.length
+                )
+            }
+        }
+    }
+    
+    /**
+     * Cierra el editor sin guardar.
+     */
+    fun closeEntryEditor() {
+        _uiState.update {
+            it.copy(
+                isEditingEntry = false,
+                editingEntryId = null,
+                editorText = "",
+                editorCharacterCount = 0
+            )
+        }
+    }
+    
+    /**
+     * Actualiza el texto del editor.
+     */
+    fun updateEditorText(text: String) {
+        val trimmed = text.take(300) // Limitar a 300 caracteres
+        _uiState.update {
+            it.copy(
+                editorText = trimmed,
+                editorCharacterCount = trimmed.length
+            )
+        }
+    }
+    
+    /**
+     * Guarda la entrada (nueva o editada).
+     */
+    fun saveEntry() {
+        val text = _uiState.value.editorText.trim()
         if (text.isEmpty()) return
         
+        val selectedDate = _uiState.value.selectedDate
+        val editingEntryId = _uiState.value.editingEntryId
+        
         viewModelScope.launch {
-            _uiState.update { it.copy(isSavingJournal = true) }
+            _uiState.update { it.copy(isSavingEntry = true) }
             
-            // TODO: Guardar en Repository cuando se implemente la FEATURE
-            // Por ahora, simulamos guardado
-            kotlinx.coroutines.delay(500)
+            // Simular guardado
+            kotlinx.coroutines.delay(300)
+            
+            if (editingEntryId != null) {
+                // Editar entrada existente
+                updateEntry(selectedDate, editingEntryId, text)
+            } else {
+                // Crear nueva entrada
+                addEntry(selectedDate, text)
+            }
+            
+            // Actualizar estado
+            val entries = journalEntriesByDate[selectedDate]?.toList() ?: emptyList()
+            val availableDates = journalEntriesByDate.keys.toList()
             
             _uiState.update {
                 it.copy(
-                    isSavingJournal = false,
-                    journalSaved = true,
-                    todaysJournalText = "", // Limpiar después de guardar
-                    journalCharacterCount = 0
+                    isSavingEntry = false,
+                    isEditingEntry = false,
+                    editingEntryId = null,
+                    editorText = "",
+                    editorCharacterCount = 0,
+                    entriesOfSelectedDate = entries,
+                    availableDates = availableDates
                 )
             }
-            
-            // Recargar entradas previas
-            loadDummyData()
         }
+    }
+    
+    /**
+     * Elimina una entrada.
+     */
+    fun deleteEntry(entryId: String) {
+        val selectedDate = _uiState.value.selectedDate
+        val entries = journalEntriesByDate[selectedDate] ?: return
+        
+        entries.removeAll { it.id == entryId }
+        
+        // Si no quedan entradas, remover la fecha de availableDates
+        if (entries.isEmpty()) {
+            journalEntriesByDate.remove(selectedDate)
+        }
+        
+        // Actualizar estado
+        val updatedEntries = journalEntriesByDate[selectedDate]?.toList() ?: emptyList()
+        val availableDates = journalEntriesByDate.keys.toList()
+        
+        _uiState.update {
+            it.copy(
+                entriesOfSelectedDate = updatedEntries,
+                availableDates = availableDates
+            )
+        }
+    }
+    
+    /**
+     * Agrega una nueva entrada al día especificado.
+     */
+    private fun addEntry(dateTimestamp: Long, text: String) {
+        val dayStart = getDayStartTimestamp(dateTimestamp)
+        val entryId = "entry_${System.currentTimeMillis()}"
+        val timestamp = System.currentTimeMillis()
+        
+        val entry = JournalEntry(
+            id = entryId,
+            date = formatDate(dayStart),
+            text = text,
+            timestamp = timestamp,
+            time = formatTime(timestamp)
+        )
+        
+        val entries = journalEntriesByDate.getOrPut(dayStart) { mutableListOf() }
+        entries.add(entry)
+        entries.sortByDescending { it.timestamp } // Más recientes primero
+    }
+    
+    /**
+     * Actualiza una entrada existente.
+     */
+    private fun updateEntry(dateTimestamp: Long, entryId: String, newText: String) {
+        val dayStart = getDayStartTimestamp(dateTimestamp)
+        val entries = journalEntriesByDate[dayStart] ?: return
+        
+        val index = entries.indexOfFirst { it.id == entryId }
+        if (index >= 0) {
+            val oldEntry = entries[index]
+            entries[index] = oldEntry.copy(
+                text = newText,
+                timestamp = System.currentTimeMillis() // Actualizar timestamp
+            )
+            entries.sortByDescending { it.timestamp }
+        }
+    }
+    
+    /**
+     * Inicializa algunas entradas dummy para desarrollo.
+     */
+    private fun initializeDummyJournalEntries() {
+        val today = System.currentTimeMillis()
+        val yesterday = today - (24 * 60 * 60 * 1000L)
+        val twoDaysAgo = yesterday - (24 * 60 * 60 * 1000L)
+        
+        // Entrada de hoy
+        addEntry(today, "Today I discovered some amazing lofi tracks that helped me focus while studying. The ambient sounds really improved my productivity.")
+        
+        // Entrada de ayer
+        addEntry(yesterday, "Yesterday was a great day for music discovery. Found several new artists that I'm excited to explore more.")
+        
+        // Entrada de hace dos días
+        addEntry(twoDaysAgo, "Started the week with a fresh playlist. Music really sets the mood for the day ahead.")
+        
+        // Actualizar estado inicial
+        val dayStart = getDayStartTimestamp(today)
+        val entries = journalEntriesByDate[dayStart]?.toList() ?: emptyList()
+        val availableDates = journalEntriesByDate.keys.toList()
+        
+        _uiState.update {
+            it.copy(
+                selectedDate = dayStart,
+                entriesOfSelectedDate = entries,
+                availableDates = availableDates
+            )
+        }
+    }
+    
+    /**
+     * Obtiene el timestamp del inicio del día (00:00:00).
+     */
+    private fun getDayStartTimestamp(timestamp: Long): Long {
+        val calendar = java.util.Calendar.getInstance()
+        calendar.timeInMillis = timestamp
+        calendar.set(java.util.Calendar.HOUR_OF_DAY, 0)
+        calendar.set(java.util.Calendar.MINUTE, 0)
+        calendar.set(java.util.Calendar.SECOND, 0)
+        calendar.set(java.util.Calendar.MILLISECOND, 0)
+        return calendar.timeInMillis
+    }
+    
+    /**
+     * Formatea una fecha para mostrar.
+     */
+    private fun formatDate(timestamp: Long): String {
+        val calendar = java.util.Calendar.getInstance()
+        calendar.timeInMillis = timestamp
+        val today = java.util.Calendar.getInstance()
+        val yesterday = java.util.Calendar.getInstance().apply {
+            add(java.util.Calendar.DAY_OF_YEAR, -1)
+        }
+        
+        return when {
+            isSameDay(calendar, today) -> "Today"
+            isSameDay(calendar, yesterday) -> "Yesterday"
+            else -> {
+                val dayOfWeek = calendar.get(java.util.Calendar.DAY_OF_WEEK)
+                val month = calendar.get(java.util.Calendar.MONTH)
+                val day = calendar.get(java.util.Calendar.DAY_OF_MONTH)
+                val dayNames = arrayOf("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
+                val monthNames = arrayOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+                "${dayNames[dayOfWeek - 1]} · ${monthNames[month]} $day"
+            }
+        }
+    }
+    
+    /**
+     * Formatea una hora para mostrar.
+     */
+    private fun formatTime(timestamp: Long): String {
+        val calendar = java.util.Calendar.getInstance()
+        calendar.timeInMillis = timestamp
+        val hour = calendar.get(java.util.Calendar.HOUR_OF_DAY)
+        val minute = calendar.get(java.util.Calendar.MINUTE)
+        val amPm = if (hour < 12) "AM" else "PM"
+        val displayHour = when {
+            hour == 0 -> 12
+            hour > 12 -> hour - 12
+            else -> hour
+        }
+        return String.format("%d:%02d %s", displayHour, minute, amPm)
+    }
+    
+    /**
+     * Verifica si dos calendarios representan el mismo día.
+     */
+    private fun isSameDay(cal1: java.util.Calendar, cal2: java.util.Calendar): Boolean {
+        return cal1.get(java.util.Calendar.YEAR) == cal2.get(java.util.Calendar.YEAR) &&
+                cal1.get(java.util.Calendar.DAY_OF_YEAR) == cal2.get(java.util.Calendar.DAY_OF_YEAR)
     }
     
     /**
@@ -159,16 +423,8 @@ class ActivityStatsViewModel : ViewModel() {
                         )
                     )
                 ),
-                previousEntries = emptyList() // Se llenará cuando haya entradas guardadas
             )
         }
-    }
-    
-    /**
-     * Limpia el mensaje de éxito del diario.
-     */
-    fun clearJournalSavedMessage() {
-        _uiState.update { it.copy(journalSaved = false) }
     }
 }
 


### PR DESCRIPTION
Refactor the Journal feature to support complete Create, Read, Update, and Delete (CRUD) operations for entries.

- **Multi-Entry Per Day:** Users can now create, view, edit, and delete multiple journal entries for any given day.
- **Date Navigation:** Implemented a date selector with back and next buttons to navigate between days that have journal entries.
- **Entry Editor:** Introduced a modal editor for creating and editing journal entries, replacing the previous single-entry text field.
- **Entry Management:** Added UI components for listing entries, with options to edit or delete each one.
- **View Full Entry:** A modal bottom sheet is now used to display the full text of a journal entry when selected.
- **ViewModel Logic:** The `ActivityStatsViewModel` has been updated to manage the state for the new CRUD operations, including handling selected dates, editor state, and entry management.
- **UI Enhancements:** The `ActivityStatsScreen` now includes a top app bar with a back button and a restructured layout to accommodate the enhanced journal functionality.